### PR TITLE
Implement force authentication for specific CIRDs

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -46,7 +46,9 @@ return array(
 	'simplesaml:settings:sources:configuration:auto_link' => "Automaticly link existing accounts based on profile information (optional)",
 	'simplesaml:settings:sources:configuration:auto_link:description' => "If the external authentication source provides the configured profile information, both accounts will be linked automaticly.",
 	'simplesaml:settings:sources:configuration:auto_link:none' => "Don't allow automatic linking",
-	
+	'simplesaml:settings:sources:configuration:force_authentication_cidrs' => "Only enable Force authentication for the following defined CIDR (optional)",
+	'simplesaml:settings:sources:configuration:force_authentication_cidrs:description' => "Comma seperated list of CIDRs to enable Force authentication for, useful for authenticating using SSO on an intranet. Keep empty for always.",
+
 	'simplesaml:settings:sources:configuration:access' => "Advanced access options",
 	'simplesaml:settings:sources:configuration:access:description' => "You can further limit the access of authorized SAML users by adding an extra filter below. You can explicitly allow user who match the settings or deny users who match the settings. The matching checks all values of the configured field (for example mulitple group values) if one of the values matches the user is allowed or denied. If eighter the field name or value is empty no additional validation will be applied.",
 	'simplesaml:settings:sources:configuration:access_type:allow' => "Allow access",

--- a/languages/nl.php
+++ b/languages/nl.php
@@ -36,6 +36,8 @@ return array (
   'simplesaml:settings:sources:configuration:auto_link' => 'Link accounts automatisch op basis van profiel informatie (optioneel)',
   'simplesaml:settings:sources:configuration:auto_link:description' => 'Als de externe authenticatie bron de geconfigureerde profiel informatie aanlevert, zullen beide accounts automatisch gelinkt worden.',
   'simplesaml:settings:sources:configuration:auto_link:none' => 'Automatisch linken niet toestaan',
+  'simplesaml:settings:sources:configuration:force_authentication_cidrs' => "Schakel Forceer authenticatie alleen in voor de volgende CIDRs (optional)",
+  'simplesaml:settings:sources:configuration:force_authentication_cidrs:description' => "Komma gescheiden lijst van CIDRs om Forceer authenticatie voor aan te zetten, handig voor SSO binnen een intranet. Houd leeg voor altijd.",
   'simplesaml:settings:warning:configuration:sources' => 'Er zijn nog geen authenticatie bronnen geconfigureerd',
   'simplesaml:settings:idp' => 'IDentity Provider configuratie voor: %s',
   'simplesaml:settings:idp:description' => 'Hier kan worden geconfigureerd welke profiel informatie wordt vrijgegeven in het SAML authenticatie proces.',

--- a/views/default/simplesaml/settings/service_provider_advanced.php
+++ b/views/default/simplesaml/settings/service_provider_advanced.php
@@ -50,6 +50,19 @@ if ($source_id_type == 'saml') {
 	$body .= elgg_format_element('div', [], $external_id);
 }
 
+$force_authentication = $plugin->getSetting('force_authentication');
+if ($force_authentication == $source_id) {
+	// Only show when the current sourec has the force authentication enabled
+
+	$force_authentication_cidrs = elgg_echo('simplesaml:settings:sources:configuration:force_authentication_cidrs');
+	$force_authentication_cidrs .= elgg_view('input/text', [
+		'name' => "params[force_authentication_cidrs]",
+		'value' => $plugin->getSetting("force_authentication_cidrs"),
+	]);
+	$force_authentication_cidrs .= elgg_format_element('div', ['class' => 'elgg-subtext'], elgg_echo('simplesaml:settings:sources:configuration:force_authentication_cidrs:description'));
+	$body .= elgg_format_element('div', [], $force_authentication_cidrs);
+}
+
 // advanced access options
 $body .= elgg_format_element('h4', ['class' => 'mtm'], elgg_echo('simplesaml:settings:sources:configuration:access'));
 $body .= elgg_view('output/longtext', [


### PR DESCRIPTION
Is useful for intranet, where SSO is forced and outside the network
isn't. Outside the network users should be able to login with something
like ldap_auth to authenticate against there SSO account through Elgg.