### PR TITLE
Fixed issue where custom user id isn't visible for SAML

### DIFF
--- a/views/default/plugins/simplesaml/settings.php
+++ b/views/default/plugins/simplesaml/settings.php
@@ -144,6 +144,7 @@ if (!empty($sources)) {
 				echo elgg_view('simplesaml/settings/service_provider_advanced', [
 					'plugin' => $plugin,
 					'source_id' => $source_id,
+					'source_id_type' => $source_type,
 					'auto_link_options' => $auto_link_options,
 					'access_type_options' => $access_type_options,
 					'access_matching_options' => $access_matching_options,

--- a/views/default/simplesaml/settings/service_provider_advanced.php
+++ b/views/default/simplesaml/settings/service_provider_advanced.php
@@ -5,6 +5,7 @@
 
 $plugin = elgg_extract('plugin', $vars);
 $source_id = elgg_extract('source_id', $vars);
+$source_id_type = elgg_extract('source_id_type', $vars);
 
 if (!($plugin instanceof ElggPlugin) || empty($source_id)) {
 	return;


### PR DESCRIPTION
The ability to enter a custom user id wasn't visible for SAML, because a required variable was missing.